### PR TITLE
Disable darkmode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,6 +1,7 @@
 <pre class='metadata'>
 Title: SOLID-OIDC
 Boilerplate: issues-index no
+Boilerplate: style-darkmode off
 Shortname: solid-oidc
 Level: 1
 Status: w3c/ED


### PR DESCRIPTION
Bikeshed's Darkmode styles are sometimes completely unreadable and don't seem really accessible in their current state.
Therefore, I would advocate to disable it.

See also: https://github.com/tabatkins/bikeshed/issues/1806