### PR TITLE
Revert "Run bikeshed locally and ignore generated files"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-*~
-*.html
-*.mmd.svg

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Requires
-# python3 -m pip install --upgrade pip
-# python3 -m pip install --upgrade bikeshed
-# bikeshed update (to get the latest autolinking data)
-
-for bsdoc in ./index.bs ./primer/index.bs; do bikeshed spec $bsdoc; done
-for diagram in primer/*.mmd; do docker run --rm -v "$PWD:/data" minlag/mermaid-cli -i /data/$diagram; done


### PR DESCRIPTION
Reverts solid/solid-oidc#5

In fact, this does break the publication of our spec. I now see a 404 at https://solid.github.io/solid-oidc/