### PR TITLE
Amend GitHub pages publish

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -34,8 +34,15 @@ jobs:
       - name: generate svg
         run: for diagram in primer/*.mmd; do docker run --rm -v "$PWD:/data" minlag/mermaid-cli -i /data/$diagram; done
 
-      - name: deploy
+      - name: create dist
+        run: |
+          mkdir dist
+          for file in index.html basic-flow-diagram.png; do cp $file ./dist/; done
+          cp -R ./primer dist/
+          for file in ./dist/primer/*.{mmd,bs}; do rm $file; done
+
+      - name: publish GitHub pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          publish_dir: .
+          publish_dir: ./dist
           personal_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *.html
 *.mmd.svg
+dist


### PR DESCRIPTION
This fixes the publication of generated assets to the `gh-pages` branch of the repository.

See in action:
- https://github.com/matthieubosquet/solid-oidc/actions/runs/1052036953
- https://github.com/matthieubosquet/solid-oidc/tree/gh-pages

Supersedes https://github.com/solid/solid-oidc/pull/7