### PR TITLE
more common sequence diagram

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -30,12 +30,12 @@ jobs:
         run: for bsdoc in ./*.bs ./**/*.bs; do bikeshed spec $bsdoc; done
 
       - name: Generate SVG
-        run: for diagram in primer/*.mmd; do docker run --rm -v "$PWD:/data" minlag/mermaid-cli -i /data/$diagram; done
+        run: for diagram in ./*.mmd primer/*.mmd; do docker run --rm -v "$PWD:/data" minlag/mermaid-cli -i /data/$diagram; done
 
       - name: Create publication
         run: |
           mkdir publish
-          for file in index.html basic-flow-diagram.png; do cp $file ./publish/; done
+          for file in index.html *./svg; do cp $file ./publish/; done
           cp -R ./primer publish/
           for file in ./publish/primer/*.{mmd,bs}; do rm $file; done
 

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -30,5 +30,4 @@ jobs:
         run: for bsdoc in ./*.bs ./**/*.bs; do bikeshed spec $bsdoc; done
 
       - name: Generate SVG
-        run: for diagram in primer/*.mmd; do docker run --rm -v "$PWD:/data" minlag/mermaid-cli -i /data/$diagram; done
-
+        run: for diagram in ./*.mmd primer/*.mmd; do docker run --rm -v "$PWD:/data" minlag/mermaid-cli -i /data/$diagram; done

--- a/index.bs
+++ b/index.bs
@@ -152,12 +152,13 @@ The basic authentication and authorization flow is as follows:
 4. If granted, the Client presents the Authorization Code and a DPoP proof, to the Token Endpoint.
 5. The Token Endpoint returns a DPoP-bound Access Token and OIDC ID Token, to the Client.
 6. The Client presents the DPoP-bound Access Token and DPoP proof, to the RS.
-7. The RS gets the public key from the IdP and uses it to validate the signature on the DPoP-bound Access Token (JWS).
-8. If the DPoP proof and Access Token are valid, then the RS returns the requested resource.
+7. The RS gets user's WebID Document and check for designated OIDC issuers
+8. The RS gets the public key from the IdP and uses it to validate the signature on the DPoP-bound Access Token (JWS).
+9. If IdP is designated by the user and Access Token is valid, then the RS returns the requested resource.
 
 <figure id="fig-signature">
-    <img src="basic-flow-diagram.png" />
-    <figcaption>Basic flow of authentication and authorization as described above.</figcaption>
+    <img src="sequence.mmd.svg" />
+    <figcaption>Basic sequence of authentication and authorization as described above.</figcaption>
 </figure>
 
 # Client Identifiers # {#clientids}

--- a/sequence.mmd
+++ b/sequence.mmd
@@ -1,0 +1,17 @@
+sequenceDiagram
+  participant RC as Resource Client
+  participant RS as Resource Server
+  participant OP as OpenID Provider
+  participant WebID as User's WebID Document
+  RC ->> RS: 1. unauthenticated request
+  RS ->> RC: 2. 401 with a WWW-Authenticate HTTP header
+  RC ->> OP: 3. start Authorization Code grant
+  OP ->> RC: return Authorization Code
+  RC ->> OP: 4. present Authorization Code and DPoP proof
+  OP ->> RC: 5. return DPoP bound Access Token and OIDC ID Token
+  RC ->> RS: 6. Access Token + DPoP proof
+  RS ->> WebID: 7. get WebID document to verify Issuer
+  WebID ->> RS: WebID document
+  RS ->> OP: 8. get OP's public key to verify Access Token (JWS)
+  OP ->> RS: JWKS
+  RS ->> RC: 9. if all checks pass respond with representation


### PR DESCRIPTION
This PR will replace sequence diagram in the spec with one using more common format.

![Screen Shot 2021-08-02 at 8 10 25](https://user-images.githubusercontent.com/876431/127867225-b2dc521b-d359-4145-8aa3-90e9937210bd.png)

Currenly section in a spec has 8 bullet points, this diagram has 12. It splits 2 bi-directional arrows into separate req/res and adds req/res for getting user's WebID profile. If we agree on those changes I'll adjust bullet points in the spec and change from draft to PR.

