### PR TITLE
Solid-OIDC capitalization

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: SOLID-OIDC
+Title: Solid-OIDC
 Boilerplate: issues-index no
 Boilerplate: style-darkmode off
 Shortname: solid-oidc


### PR DESCRIPTION
The correct capitalization is Solid-OIDC, and this PR changes the title of the document to that form.