### PR TITLE
Adjust SVG file pattern for CD

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Create publication
         run: |
           mkdir publish
-          for file in index.html *./svg; do cp $file ./publish/; done
+          for file in index.html *.svg; do cp $file ./publish/; done
           cp -R ./primer publish/
           for file in ./publish/primer/*.{mmd,bs}; do rm $file; done
 


### PR DESCRIPTION
The file pattern for SVG files is causing CD to fail. This should fix it.