### PR TITLE
Include post_logout_redirect_uris in JSON-LD context

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -201,6 +201,7 @@ This example uses [JSON-LD ](https://www.w3.org/TR/json-ld11/) for the Client ID
           "client_id": "https://app.example/id",
           "client_name": "Solid Application Name",
           "redirect_uris": ["https://app.example/callback"],
+          "post_logout_redirect_uris": ["https://app.example/logout"],
           "client_uri": "https://app.example/",
           "logo_uri" : "https://app.example/logo.png",
           "tos_uri" : "https://app.example/tos.html",
@@ -253,6 +254,14 @@ The JSON-LD context is defined as:
             },
             "redirect_uris": {
               "@id": "oidc:redirect_uris",
+              "@type": "@id",
+              "@container": [
+                "@id",
+                "@set"
+              ]
+            },
+            "post_logout_redirect_uris": {
+              "@id": "oidc:post_logout_redirect_uris",
               "@type": "@id",
               "@container": [
                 "@id",

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -293,6 +293,7 @@ Response:
   "client_id": "https://decentphtos.example/webid#this",
   "client_name": "DecentPhotos",
   "redirect_uris": [ "https://decentphotos.example/callback" ],
+  "post_logout_redirect_uris": [ "https://decentphotos.example/logout" ],
   "client_uri": "https://decentphotos.example/",
   "logo_uri": "https://decentphotos.example/logo.png",
   "tos_uri": "https://decentphotos.example/tos.html",


### PR DESCRIPTION
For Solid-OIDC servers implementing RP-initiated logout, the `post_logout_redirect_uris` property will need to be defined in the corresponding Solid vocabularies.

See also https://github.com/solid/vocab/pull/63