### PR TITLE
Refer to the azp rather than ClientId claim

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -246,16 +246,14 @@ With the `webid` scope, the DPoP-bound OIDC ID Token payload MUST contain these 
  * `webid` — The WebID claim MUST be the user's WebID.
  * `iss` — The issuer claim MUST be a valid URL of the OP
     instantiating this token.
- * `aud` — The audience claim MUST be an array of values,
-    one of which is the authorized party claim is used to identify
-    the client. (See also: [section 5. Client Identifiers](#clientids)).
-    another one is the string `solid`.
+ * `aud` — The audience claim MUST be an array of values.
+    The values MUST include the authorized party claim `azp`
+    and the string `solid`.
     In the decentralized world
-    of Solid OIDC, the audience of an ID Token is not only the client,
-    but also a Solid Authorization Server;
-    that is, any Solid Authorization Server at any accessible address
-    on the world wide web. See also: [[RFC7519#section-4.1.3]].
- * `azp` - The authorized party claim is used to identify the client.
+    of Solid OIDC, the audience of an ID Token is not only the client (`azp`),
+    but also any Solid Authorization Server at any accessible address
+    on the world wide web (`solid`). See also: [[RFC7519#section-4.1.3]].
+ * `azp` - The authorized party claim is used to identify the client
     (See also: [section 5. Client Identifiers](#clientids)).
  * `iat` — The issued-at claim is the time at which the DPoP-bound
     OIDC ID Token was issued.

--- a/index.bs
+++ b/index.bs
@@ -247,15 +247,15 @@ With the `webid` scope, the DPoP-bound OIDC ID Token payload MUST contain these 
  * `iss` — The issuer claim MUST be a valid URL of the OP
     instantiating this token.
  * `aud` — The audience claim MUST be an array of values,
-    one of which is the ClientID claim is used to identify the client.
-    (See also: [section 5. Client Identifiers](#clientids)).
+    one of which is the authorized party claim is used to identify
+    the client. (See also: [section 5. Client Identifiers](#clientids)).
     another one is the string `solid`.
     In the decentralized world
     of Solid OIDC, the audience of an ID Token is not only the client,
     but also a Solid Authorization Server;
     that is, any Solid Authorization Server at any accessible address
     on the world wide web. See also: [[RFC7519#section-4.1.3]].
- * `azp` - The ClientID claim is used to identify the client.
+ * `azp` - The authorized party claim is used to identify the client.
     (See also: [section 5. Client Identifiers](#clientids)).
  * `iat` — The issued-at claim is the time at which the DPoP-bound
     OIDC ID Token was issued.


### PR DESCRIPTION
Referring to the `ClientID` claim is confusing, especially since there used to be a `client_id` claim and OAuth 2.0 uses `client_id`. Instead, this changes the word "ClientID" to "authorized party" to align with the JWT claims being used.