### PR TITLE
Add dependabot for GH action version management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+


### PR DESCRIPTION
This will help us keep any GH action dependencies up-to-date