### PR TITLE
Update to latest draft of DPoP

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -540,7 +540,7 @@ The JSON-LD context is defined as:
             "M. Jones",
             "D. Waite"
         ],
-        "href": "https://tools.ietf.org/html/draft-ietf-oauth-dpop-04",
+        "href": "https://tools.ietf.org/html/draft-ietf-oauth-dpop",
         "title": "OAuth 2.0 Demonstration of Proof-of-Possession at the Application Layer (DPoP)",
         "publisher": "IETF"
     },

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -358,7 +358,7 @@ This redirect gives decentphotos the code that it will exchange for an access to
 <h4 id="authorization-code-pkce-flow-step-12" class="no-num">12. Generates a DPoP Client Key Pair</h4>
 
 Solid-OIDC depends on
-[Demonstration of Proof-of-Possession (DPoP) tokens](https://tools.ietf.org/html/draft-ietf-oauth-dpop-03).
+[Demonstration of Proof-of-Possession (DPoP) tokens](https://tools.ietf.org/html/draft-ietf-oauth-dpop).
 DPoP tokens ensure that third-party web applications can send requests to any number of
 Storage servers while ensuring that malicious actors can't steal and replay a user's token.
 


### PR DESCRIPTION
By including version numbers in the DPoP draft spec labels, we have to keep chasing these updates. Without the versions, we just need to ensure that the sections continue to align. Since some of us (I, at least) keep close track of the DPoP spec, this seems like an easier way to point implementors to the correct version