### PR TITLE
Require solid-oidc context in JSON-LD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -165,7 +165,7 @@ SHOULD use a URI that can be dereferenced as a [Client ID Document](#clientids-d
 When a Client Identifier is dereferenced, the resource MUST be serialized as an `application/ld+json` document
 unless content negotiation requires a different outcome.
 
-The serialized JSON form of a Client ID Document SHOULD use the normative JSON-LD `@context`
+The serialized JSON form of a Client ID Document MUST use the normative JSON-LD `@context`
 provided at `https://www.w3.org/ns/solid/oidc-context.jsonld` such that the resulting
 document produces a JSON serialization of an OIDC client registration, per the
 definition of client registration metadata from [[!RFC7591]] section 2.
@@ -183,7 +183,7 @@ This example uses [JSON-LD ](https://www.w3.org/TR/json-ld11/) for the Client ID
 
     <pre highlight="jsonld">
         {
-          "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
+          "@context": ["https://www.w3.org/ns/solid/oidc-context.jsonld"],
 
           "client_id": "https://app.example/id",
           "client_name": "Solid Application Name",

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -291,7 +291,7 @@ GET https://decentphotos.example/webid
 Response:
 ```jsonld
 {
-  "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
+  "@context": [ "https://www.w3.org/ns/solid/oidc-context.jsonld" ],
 
   "client_id": "https://decentphtos.example/webid#this",
   "client_name": "DecentPhotos",
@@ -308,9 +308,9 @@ Response:
 }
 ```
 
-Notice that the application Client ID Document contains JSON-LD representation of an
+Notice that the application Client ID Document contains a JSON-LD representation of an
 [OIDC Client Registration](https://tools.ietf.org/html/rfc7591#section-2).
-It also have to use specific <code>"@context": "https://www.w3.org/ns/solid/oidc-context.jsonld"</code>.
+It also must use the specific <code>"@context": ["https://www.w3.org/ns/solid/oidc-context.jsonld"]</code>.
 
 <h4 id="authorization-code-pkce-flow-step-8" class="no-num">8. Validate redirect url with Client ID Document</h4>
 


### PR DESCRIPTION
There are three changes here, only one of which is significant.

The significant one changes the `SHOULD` to a `MUST` in the requirement for client identifier documents to use the normatively defined Solid-OIDC JSON-LD `@context`.

The rationale for this is simple: it makes for better interoperability.

If client identifier documents all use the same `@context`, then there will be less variation in how this data is serialized across the Solid ecosystem. Furthermore, other specifications that use particular context resources to structure JSON-LD data normatively require (`MUST`) the use of a defined context. For example:

* [W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model/#contexts)
* [W3C Web Annotations](https://www.w3.org/TR/annotation-model/#annotations)
* [IIIF Presentation API](https://iiif.io/api/presentation/3.0/#46-linked-data-context-and-extensions)

Less significantly, this changes the examples to use arrays for the `@context` property, as a way to suggest greater extensibility while also fixing some grammar.