### PR TITLE
Change status to 'Community Group Draft'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5,7 +5,7 @@ Boilerplate: style-darkmode off
 Local Boilerplate: logo yes
 Shortname: solid-oidc
 Level: 1
-Status: w3c/ED
+Status: w3c/CG-DRAFT
 Group: Solid Community Group
 Favicon: https://solid.github.io/solid-oidc/solid.svg
 ED: https://solid.github.io/solid-oidc/

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -4,7 +4,7 @@ Boilerplate: issues-index no
 Boilerplate: style-darkmode off
 Shortname: solid-oidc-primer
 Level: 1
-Status: w3c/ED
+Status: w3c/CG-DRAFT
 Group: Solid Community Group
 ED: https://solid.github.io/solid-oidc/primer/
 Repository: https://github.com/solid/solid-oidc


### PR DESCRIPTION
This changes the status of the Solid-OIDC draft specification from 'Editors Draft' to 'Community Group Draft'.

This is roughly equivalent to a "First Public Working Draft", as the panel prepares for a "~Candidate Recommendation" status