### PR TITLE
Set editor's draft as ED status

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5,7 +5,7 @@ Boilerplate: style-darkmode off
 Local Boilerplate: logo yes
 Shortname: solid-oidc
 Level: 1
-Status: w3c/CG-DRAFT
+Status: w3c/ED
 Group: Solid Community Group
 Favicon: https://solid.github.io/solid-oidc/solid.svg
 ED: https://solid.github.io/solid-oidc/

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -4,7 +4,7 @@ Boilerplate: issues-index no
 Boilerplate: style-darkmode off
 Shortname: solid-oidc-primer
 Level: 1
-Status: w3c/CG-DRAFT
+Status: w3c/ED
 Group: Solid Community Group
 ED: https://solid.github.io/solid-oidc/primer/
 Repository: https://github.com/solid/solid-oidc


### PR DESCRIPTION
Resolves #98 

Depends on https://github.com/solid/specification/pull/386

Once the `CG-DRAFT` version is accepted into the protocol spec, this version will go back to being an editor's draft.