### PR TITLE
Improve the TR draft workflow

### DIFF
--- a/.github/workflows/tr-draft-config.yml
+++ b/.github/workflows/tr-draft-config.yml
@@ -26,10 +26,19 @@ jobs:
           python3 -m pip install --upgrade bikeshed
           bikeshed update
 
-      - name: Adjust document status to CG-DRAFT
+      - name: Adjust document status and URLs
+        shell: bash
         run: |
-          sed -i 's|w3c/ED|w3c/CG-DRAFT|g' index.bs
-          sed -i 's|w3c/ED|w3c/CG-DRAFT|g' primer/index.bs
+          YEAR=$(date '+%Y')
+          DAY=$(date '+%Y%m%d')
+
+          sed -i "s|w3c/ED|w3c/CG-DRAFT|g" index.bs
+          sed -i "s|ED: https://solid.github.io/solid-oidc/|ED: https://solidproject.org/TR/$YEAR/oidc-$DAY|g" index.bs
+          sed -i "s|Editor's Draft off|Editor's Draft on|" index.bs
+
+          sed -i "s|w3c/ED|w3c/CG-DRAFT|g" primer/index.bs
+          sed -i "s|ED: https://solid.github.io/solid-oidc/primer/|ED: https://solidproject.org/TR/$YEAR/oidc-primer-$DAY|g" primer/index.bs
+          sed -i "s|Editor's Draft off|Editor's Draft on|" index.bs
 
       - name: Generate HTML
         run: for bsdoc in ./*.bs ./**/*.bs; do bikeshed spec $bsdoc; done
@@ -44,17 +53,13 @@ jobs:
           cp index.html ./publish/oidc.html
           cp sequence.mmd.svg ./publish/oidc-sequence.svg
           sed -i "s|sequence.mmd.svg|oidc-sequence.svg|g" ./publish/oidc.html
-          sed -i "s|https://solid.github.io/solid-oidc/solid.svg|https://solidproject.org/TR/solid.svg|g" ./publish/oidc.html
           sed -i "s|https://solid.github.io/solid-oidc/primer/|https://solidproject.org/TR/oidc-primer|g" ./publish/oidc.html
-          sed -i "s|https://solid.github.io/solid-oidc/|https://solidproject.org/TR/oidc|g" ./publish/oidc.html
 
           cp primer/index.html ./publish/oidc-primer.html
           cp primer/primer-login.mmd.svg ./publish/oidc-primer-login.svg
           cp primer/primer-request.mmd.svg ./publish/oidc-primer-request.svg
           sed -i "s|primer-login.mmd.svg|oidc-primer-login.svg|g" ./publish/oidc-primer.html
           sed -i "s|primer-request.mmd.svg|oidc-primer-request.svg|g" ./publish/oidc-primer.html
-          sed -i "s|https://solid.github.io/solid-oidc/solid.svg|https://solidproject.org/TR/solid.svg|g" ./publish/oidc-primer.html
-          sed -i "s|https://solid.github.io/solid-oidc/primer/|https://solidproject.org/TR/oidc-primer|g" ./publish/oidc-primer.html
           sed -i "s|https://solid.github.io/solid-oidc/|https://solidproject.org/TR/oidc|g" ./publish/oidc-primer.html
 
           # Perform the same tasks for a date-specific version
@@ -65,17 +70,13 @@ jobs:
           cp index.html ./publish/$YEAR/oidc-$DAY.html
           cp sequence.mmd.svg ./publish/$YEAR/oidc-sequence-$DAY.svg
           sed -i "s|sequence.mmd.svg|oidc-sequence-$DAY.svg|g" ./publish/$YEAR/oidc-$DAY.html
-          sed -i "s|https://solid.github.io/solid-oidc/solid.svg|https://solidproject.org/TR/solid.svg|g" ./publish/$YEAR/oidc-$DAY.html
           sed -i "s|https://solid.github.io/solid-oidc/primer/|https://solidproject.org/TR/oidc-primer|g" ./publish/$YEAR/oidc-$DAY.html
-          sed -i "s|https://solid.github.io/solid-oidc/|https://solidproject.org/TR/$YEAR/oidc-$DAY|g" ./publish/$YEAR/oidc-$DAY.html
 
           cp primer/index.html ./publish/$YEAR/oidc-primer-$DAY.html
           cp primer/primer-login.mmd.svg ./publish/$YEAR/oidc-primer-login-$DAY.svg
           cp primer/primer-request.mmd.svg ./publish/$YEAR/oidc-primer-request-$DAY.svg
           sed -i "s|primer-login.mmd.svg|oidc-primer-login-$DAY.svg|g" ./publish/$YEAR/oidc-primer-$DAY.html
           sed -i "s|primer-request.mmd.svg|oidc-primer-request-$DAY.svg|g" ./publish/$YEAR/oidc-primer-$DAY.html
-          sed -i "s|https://solid.github.io/solid-oidc/solid.svg|https://solidproject.org/TR/solid.svg|g" ./publish/$YEAR/oidc-primer-$DAY.html
-          sed -i "s|https://solid.github.io/solid-oidc/primer/|https://solidproject.org/TR/$YEAR/oidc-primer-$DAY|g" ./publish/$YEAR/oidc-primer-$DAY.html
           sed -i "s|https://solid.github.io/solid-oidc/|https://solidproject.org/TR/oidc|g" ./publish/$YEAR/oidc-primer-$DAY.html
 
       - name: Publish to TR Publication branch

--- a/.github/workflows/tr-final-config.yml
+++ b/.github/workflows/tr-final-config.yml
@@ -26,10 +26,19 @@ jobs:
           python3 -m pip install --upgrade bikeshed
           bikeshed update
 
-      - name: Adjust document status to CG-FINAL
+      - name: Adjust document status and URLs
+        shell: bash
         run: |
-          sed -i 's|w3c/ED|w3c/CG-FINAL|g' index.bs
-          sed -i 's|w3c/ED|w3c/CG-FINAL|g' primer/index.bs
+          YEAR=$(date '+%Y')
+          DAY=$(date '+%Y%m%d')
+
+          sed -i "s|w3c/ED|w3c/CG-FINAL|g" index.bs
+          sed -i "s|ED: https://solid.github.io/solid-oidc/|ED: https://solidproject.org/TR/$YEAR/oidc-$DAY|g" index.bs
+          sed -i "s|Editor's Draft off|Editor's Draft on|" index.bs
+
+          sed -i "s|w3c/ED|w3c/CG-FINAL|g" primer/index.bs
+          sed -i "s|ED: https://solid.github.io/solid-oidc/primer/|ED: https://solidproject.org/TR/$YEAR/oidc-primer-$DAY|g" primer/index.bs
+          sed -i "s|Editor's Draft off|Editor's Draft on|" primer/index.bs
 
       - name: Generate HTML
         run: for bsdoc in ./*.bs ./**/*.bs; do bikeshed spec $bsdoc; done
@@ -44,17 +53,13 @@ jobs:
           cp index.html ./publish/oidc.html
           cp sequence.mmd.svg ./publish/oidc-sequence.svg
           sed -i "s|sequence.mmd.svg|oidc-sequence.svg|g" ./publish/oidc.html
-          sed -i "s|https://solid.github.io/solid-oidc/solid.svg|https://solidproject.org/TR/solid.svg|g" ./publish/oidc.html
           sed -i "s|https://solid.github.io/solid-oidc/primer/|https://solidproject.org/TR/oidc-primer|g" ./publish/oidc.html
-          sed -i "s|https://solid.github.io/solid-oidc/|https://solidproject.org/TR/oidc|g" ./publish/oidc.html
 
           cp primer/index.html ./publish/oidc-primer.html
           cp primer/primer-login.mmd.svg ./publish/oidc-primer-login.svg
           cp primer/primer-request.mmd.svg ./publish/oidc-primer-request.svg
           sed -i "s|primer-login.mmd.svg|oidc-primer-login.svg|g" ./publish/oidc-primer.html
           sed -i "s|primer-request.mmd.svg|oidc-primer-request.svg|g" ./publish/oidc-primer.html
-          sed -i "s|https://solid.github.io/solid-oidc/solid.svg|https://solidproject.org/TR/solid.svg|g" ./publish/oidc-primer.html
-          sed -i "s|https://solid.github.io/solid-oidc/primer/|https://solidproject.org/TR/oidc-primer|g" ./publish/oidc-primer.html
           sed -i "s|https://solid.github.io/solid-oidc/|https://solidproject.org/TR/oidc|g" ./publish/oidc-primer.html
 
           # Perform the same tasks for a date-specific version
@@ -65,17 +70,13 @@ jobs:
           cp index.html ./publish/$YEAR/oidc-$DAY.html
           cp sequence.mmd.svg ./publish/$YEAR/oidc-sequence-$DAY.svg
           sed -i "s|sequence.mmd.svg|oidc-sequence-$DAY.svg|g" ./publish/$YEAR/oidc-$DAY.html
-          sed -i "s|https://solid.github.io/solid-oidc/solid.svg|https://solidproject.org/TR/solid.svg|g" ./publish/$YEAR/oidc-$DAY.html
           sed -i "s|https://solid.github.io/solid-oidc/primer/|https://solidproject.org/TR/oidc-primer|g" ./publish/$YEAR/oidc-$DAY.html
-          sed -i "s|https://solid.github.io/solid-oidc/|https://solidproject.org/TR/$YEAR/oidc-$DAY|g" ./publish/$YEAR/oidc-$DAY.html
 
           cp primer/index.html ./publish/$YEAR/oidc-primer-$DAY.html
           cp primer/primer-login.mmd.svg ./publish/$YEAR/oidc-primer-login-$DAY.svg
           cp primer/primer-request.mmd.svg ./publish/$YEAR/oidc-primer-request-$DAY.svg
           sed -i "s|primer-login.mmd.svg|oidc-primer-login-$DAY.svg|g" ./publish/$YEAR/oidc-primer-$DAY.html
           sed -i "s|primer-request.mmd.svg|oidc-primer-request-$DAY.svg|g" ./publish/$YEAR/oidc-primer-$DAY.html
-          sed -i "s|https://solid.github.io/solid-oidc/solid.svg|https://solidproject.org/TR/solid.svg|g" ./publish/$YEAR/oidc-primer-$DAY.html
-          sed -i "s|https://solid.github.io/solid-oidc/primer/|https://solidproject.org/TR/$YEAR/oidc-primer-$DAY|g" ./publish/$YEAR/oidc-primer-$DAY.html
           sed -i "s|https://solid.github.io/solid-oidc/|https://solidproject.org/TR/oidc|g" ./publish/$YEAR/oidc-primer-$DAY.html
 
       - name: Publish to TR Publication branch

--- a/index.bs
+++ b/index.bs
@@ -7,8 +7,10 @@ Shortname: solid-oidc
 Level: 1
 Status: w3c/CG-DRAFT
 Group: Solid Community Group
-Favicon: https://solid.github.io/solid-oidc/solid.svg
+Favicon: https://solidproject.org/TR/solid.svg
 ED: https://solid.github.io/solid-oidc/
+TR: https://solidproject.org/TR/oidc
+!Editor's Draft: [https://solid.github.io/solid-oidc/](https://solid.github.io/solid-oidc/)
 Repository: https://github.com/solid/solid-oidc
 Inline Github Issues: title
 Markup Shorthands: markdown yes
@@ -19,6 +21,8 @@ Editor: [Dmitri Zagidulin](http://computingjoy.com/)
 Former Editor: [Adam Migus](https://migusgroup.com/about/) ([The Migus Group](https://migusgroup.com/))
 Former Editor: [Ricky White](https://endlesstrax.com) ([The Migus Group](https://migusgroup.com/))
 Test Suite: https://solid.github.io/solid-oidc-tests/
+Metadata Order: This version, Latest published version, Editor's Draft, Test Suite, *, !*
+Metadata Include: Editor's Draft off
 Abstract:
   A key challenge on the path toward re-decentralizing user data on the Worldwide Web is the need to
   access multiple potentially untrusted resources servers securely. This document aims to address that

--- a/index.bs
+++ b/index.bs
@@ -5,7 +5,7 @@ Boilerplate: style-darkmode off
 Local Boilerplate: logo yes
 Shortname: solid-oidc
 Level: 1
-Status: w3c/CG-DRAFT
+Status: w3c/ED
 Group: Solid Community Group
 Favicon: https://solidproject.org/TR/solid.svg
 ED: https://solid.github.io/solid-oidc/

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -6,13 +6,18 @@ Shortname: solid-oidc-primer
 Level: 1
 Status: w3c/CG-DRAFT
 Group: Solid Community Group
+Favicon: https://solidproject.org/TR/solid.svg
 ED: https://solid.github.io/solid-oidc/primer/
+TR: https://solidproject.org/TR/oidc-primer
+!Editor's Draft: [https://solid.github.io/solid-oidc/primer/](https://solid.github.io/solid-oidc/primer/)
 Repository: https://github.com/solid/solid-oidc
 Markup Shorthands: markdown yes
 Max ToC Depth: 2
 Editor: [Jackson Morgan](https://github.com/jaxoncreed)
 Editor: [Aaron Coburn](https://github.com/acoburn)
 Editor: [Matthieu Bosquet](https://github.com/matthieubosquet)
+Metadata Order: This version, Latest published version, Editor's Draft, Test Suite, *, !*
+Metadata Include: Editor's Draft off
 Abstract:
   The Solid OpenID Connect (Solid OIDC) specification defines how resource servers
   verify the identity of relying parties and end users based on the authentication

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -4,7 +4,7 @@ Boilerplate: issues-index no
 Boilerplate: style-darkmode off
 Shortname: solid-oidc-primer
 Level: 1
-Status: w3c/CG-DRAFT
+Status: w3c/ED
 Group: Solid Community Group
 Favicon: https://solidproject.org/TR/solid.svg
 ED: https://solid.github.io/solid-oidc/primer/


### PR DESCRIPTION
This improves the workflow for preparing the Solid-OIDC documents for publication in solidproject.org/TR by operating on the bikeshed document directly rather than replacing URLs in the produced HTML.

This also makes more effective use of the bikeshed metadata ordering mechanism