### PR TITLE
Use consistent naming for Solid-OIDC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -311,7 +311,7 @@ With the `webid` scope, the DPoP-bound OIDC ID Token payload MUST contain these 
     The values MUST include the authorized party claim `azp`
     and the string `solid`.
     In the decentralized world
-    of Solid OIDC, the audience of an ID Token is not only the client (`azp`),
+    of Solid-OIDC, the audience of an ID Token is not only the client (`azp`),
     but also any Solid Authorization Server at any accessible address
     on the world wide web (`solid`). See also: [[RFC7519#section-4.1.3]].
  * `azp` - The authorized party claim is used to identify the client

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: Solid OIDC Primer
+Title: Solid-OIDC Primer
 Boilerplate: issues-index no
 Boilerplate: style-darkmode off
 Boilerplate: omit conformance
@@ -21,9 +21,9 @@ Editor: [Matthieu Bosquet](https://github.com/matthieubosquet)
 Metadata Order: This version, Latest published version, Editor's Draft, Test Suite, *, !*
 Metadata Include: Editor's Draft off
 Abstract:
-  The Solid OpenID Connect (Solid OIDC) specification defines how resource servers
+  The Solid OpenID Connect (Solid-OIDC) specification defines how resource servers
   verify the identity of relying parties and end users based on the authentication
-  performed by an OpenID provider. Solid OIDC builds on top of OpenID Connect 1.0.
+  performed by an OpenID provider. Solid-OIDC builds on top of OpenID Connect 1.0.
   This primer is designed to provide the reader with the basic knowledge required
   to understand Solid OpenID Connect authentication flows. It introduces the basic
   concepts of authentication in the Solid ecosystem.
@@ -50,7 +50,7 @@ Bob's Solid Storage (resource servers).
   <dd>A server hosting resources, capable of accepting and responding to protected resource requests using access tokens. RS is one of the four roles [defined in the OAuth 2.0 specification](https://tools.ietf.org/html/rfc6749#section-1.1). [[RFC6749]]</dd>
   <dt id="solid-data-pod">Solid Storage</dt>
   <dd>A Solid compliant Resource Server as [defined in the Solid Protocol](https://solidproject.org/TR/protocol#data-pod). [[Solid.Protocol]]</dd>
-  <dt id="solid-oidc">Solid OpenID Connect (Solid OIDC)</dt>
+  <dt id="solid-oidc">Solid OpenID Connect (Solid-OIDC)</dt>
   <dd>The specification defining authentication in the Solid ecosystem. [[Solid.OIDC]]</dd>
   <dt id="webid">WebID</dt>
   <dd>A WebID is an HTTP URI which refers to an Agent (Person, Organization, Group, Device, etc.) as [defined in the WebID 1.0 specification](https://dvcs.w3.org/hg/WebID/raw-file/tip/spec/identity-respec.html#introduction). [[WebID]]</dd>
@@ -58,7 +58,7 @@ Bob's Solid Storage (resource servers).
 
 # Actors # {#actors}
 
-Several actors are at play in our example Solid OIDC authentication flows:
+Several actors are at play in our example Solid-OIDC authentication flows:
 
 <dl>
   <dt id="alice">Alice</dt>
@@ -98,13 +98,13 @@ Several actors are at play in our example Solid OIDC authentication flows:
  `https://auth.otherpod.example`.</dd>
 </dl>
 
-# Solid OIDC Flow # {#solid-oidc-flow}
+# Solid-OIDC Flow # {#solid-oidc-flow}
 
 ## Authorization Code Grant with PKCE Authorization Flow ## {#authorization-code-pkce-flow}
 
 The Authorization Code grant with PKCE is the primary OAuth 2.0 authorization flow
-recommended by the Solid OIDC. It is defined by the PKCE RFC [[RFC7636]] and
-described here in the Solid OIDC context.
+recommended by the Solid-OIDC. It is defined by the PKCE RFC [[RFC7636]] and
+described here in the Solid-OIDC context.
 
 <img src="primer-login.mmd.svg" width="980" />
 
@@ -275,7 +275,7 @@ That URL might look a little complex, but it's essentially a request to
 - `scope=openid%20webid%20offline_access`: a list of [OIDC scopes](https://auth0.com/docs/scopes/current/oidc-scopes)
     (attributes of the RS to which this token should have access) separated by spaces (%20).
     - `openid` is a scope that is needed to verify Alice's identity.
-    - `webid` is required by the Solid OIDC specification to denote a WebID login.
+    - `webid` is required by the Solid-OIDC specification to denote a WebID login.
     - `offline_access`: Is required to get a refresh token.
 - `client_id=https%3A%2F%2Fdecentphotos.example%2Fwebid%23this`: Usually the client id of a Solid
     application is the app's URI (in our case `https://decentphotos.example/webid#this`) as seen here.
@@ -970,7 +970,7 @@ Given all went well, the RS should return the requested content.
             "Dmitri Zagidulin"
         ],
         "href": "https://solid.github.io/solid-oidc/",
-        "title": "Solid OIDC",
+        "title": "Solid-OIDC",
         "publisher": "W3C"
     },
     "WebID": {


### PR DESCRIPTION
Resolves #104

The spec mostly uses Solid-OIDC, so I took that to be canonical (which is also my understanding).