### PR TITLE
Clarify core concept text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -130,7 +130,7 @@ This specification also uses the following terms:
 *This section is non-normative*
 
 In a decentralized ecosystem, such as Solid, an OP may be an identity-as-a-service vendor or, at
-the other end of the spectrum, a user-controlled OP. In any case, the user may be authenticating
+the other end of the spectrum, a user-controlled OP. In either case, the user may be authenticating
 from a browser or an application.
 
 Therefore, this specification assumes the use of the


### PR DESCRIPTION
Resolves #120 

The text "in any case" was leading to confusion. It appears that the intended formulation of that text is "in either case".

Alternatively, we could remove most of the first paragraph, if it is not helpful.