### PR TITLE
make webid scope required for DCR

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -227,6 +227,24 @@ For non-dereferencable identifiers, the Client MUST present a `client_id` value 
 registered with the OP via either OIDC dynamic or static registration.
 See also [[!OIDC-DYNAMIC-CLIENT-REGISTRATION]].
 
+When requesting Dynamic Client Registration, the Client MUST specify the `scope` in the metadata
+and include `webid` in its value (space-separated list).
+
+<div class='example'>
+    <pre highlight="jsonld" line-highlight="9">
+        {
+          "client_name": "S-C-A Browser Demo Client App",
+          "application_type": "web",
+          "redirect_uris": [
+            "https://dynamic-client.example/auth"
+          ],
+          "subject_type": "pairwise",
+          "token_endpoint_auth_method": "client_secret_basic",
+          "scope" : "openid profile offline_access webid"
+        }
+    </pre>
+</div>
+
 # WebID Profile # {#webid-profile}
 
 Dereferencing the WebID URL results in a WebID Profile.


### PR DESCRIPTION
closes #168

while https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
doesn't mention `scope`, it can be found in
https://datatracker.ietf.org/doc/html/rfc7591#section-4.1.2

should we change the normative reference?