### PR TITLE
updated RFC7235 to RFC9110

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -383,7 +383,7 @@ the verifying party MUST follow OpenID Connect Discovery 1.0 [[!OIDC-DISCOVERY]]
 
 When a Client performs an unauthenticated request to a protected resource,
 the Resource Server MUST respond with the HTTP <code>401</code> status code,
-and a <code>WWW-Authenticate</code> HTTP header. See also: [[RFC7235#section-4.1]]
+and a <code>WWW-Authenticate</code> HTTP header. See also: [[RFC9110#section-11.6.1]]
 
 The <code>WWW-Authenticate</code> HTTP header MUST include an <code>as_uri</code>
 parameter unless the authentication scheme requires a different mechanism


### PR DESCRIPTION
After bikeshed failed to build in #190 with:

> FATAL ERROR: Obsolete biblio ref: [rfc7235] is replaced by [rfc9110]. Either update the reference, or use [rfc7235 obsolete] if this is an intentionally-obsolete reference.