### PR TITLE
Update obsolete bibliographic reference (RFC 7235) to RFC 9110

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -383,7 +383,7 @@ the verifying party MUST follow OpenID Connect Discovery 1.0 [[!OIDC-DISCOVERY]]
 
 When a Client performs an unauthenticated request to a protected resource,
 the Resource Server MUST respond with the HTTP <code>401</code> status code,
-and a <code>WWW-Authenticate</code> HTTP header. See also: [[RFC7235#section-4.1]]
+and a <code>WWW-Authenticate</code> HTTP header. See also: [[RFC9110#section-11.6.1]]
 
 The <code>WWW-Authenticate</code> HTTP header MUST include an <code>as_uri</code>
 parameter unless the authentication scheme requires a different mechanism


### PR DESCRIPTION
RFC-9110 has been published and it replaces RFC-7235.

The section numbering is slightly different, and the reference for WWW-Authenticate is not at https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1

(This will also fix a currently-broken CD flow, as the validator doesn't like the outdated RFC reference)