### PR TITLE
Remove mention of Solid Process from SotD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -35,8 +35,7 @@ Status Text:
   This section describes the status of this document at the time of its publication.
 
   This document was published by the [Solid Community Group](https://www.w3.org/community/solid/) as
-  an Editor’s Draft. The sections that have been incorporated have been reviewed following the
-  [Solid process](https://github.com/solid/process). However, the information in this document is
+  an Editor’s Draft. The information in this document is
   still subject to change. You are invited to [contribute](https://github.com/solid/solid-oidc/issues)
   any feedback, comments, or questions you might have.
 

--- a/index.bs
+++ b/index.bs
@@ -2,12 +2,12 @@
 Title: Solid-OIDC
 Boilerplate: issues-index no
 Boilerplate: style-darkmode off
-Local Boilerplate: logo yes
+!Local Boilerplate: logo yes
 Shortname: solid-oidc
 Level: 1
 Status: w3c/ED
 Group: Solid Community Group
-Favicon: https://solidproject.org/TR/solid.svg
+!Favicon: https://solidproject.org/TR/solid.svg
 ED: https://solid.github.io/solid-oidc/
 TR: https://solidproject.org/TR/oidc
 !Created: July 16, 2021


### PR DESCRIPTION
PR updates the SotD section given that the [Solid CG Charter](https://www.w3.org/community/solid/charter/) supersedes Solid Process.