### PR TITLE
Fix Primer token references and details

### DIFF
--- a/primer/index.bs
+++ b/primer/index.bs
@@ -916,7 +916,7 @@ Notice that the `keys` field is an array, so an OP could have multiple public ke
 Using the `kid` value in the ID token, the AS searches the OP public keys for one that matches the
 one used to sign the ID token. If no public key is found, the AS must reject the request.
 
-Details about the `kid` can be found in the [RFC7515 section 4.1.4](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4).
+Details about the `kid` can be found in the [[RFC7515#section-4.1.4]].
 
 <h4 id="request-flow-step-13" class="no-num">13. Access Token Response</h4>
 

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -548,7 +548,8 @@ Token Header:
 ```json
 {
     "alg": "ES256",
-    "typ": "JWT"
+    "typ": "JWT",
+    "kid": "Xu68Q0ZfwDiRfWOb2UE8N77GoEQQ7q58_3gl1wsKENs"
 }
 ```
 
@@ -914,6 +915,8 @@ Notice that the `keys` field is an array, so an OP could have multiple public ke
 
 Using the `kid` value in the ID token, the AS searches the OP public keys for one that matches the
 one used to sign the ID token. If no public key is found, the AS must reject the request.
+
+Details about the `kid` can be found in the [RFC7515 section 4.1.4](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4).
 
 <h4 id="request-flow-step-13" class="no-num">13. Access Token Response</h4>
 

--- a/primer/primer-request.mmd
+++ b/primer/primer-request.mmd
@@ -13,7 +13,7 @@ sequenceDiagram
   note over AS: 5. Checks ID Token expirations
   note over AS: 6. Checks DPoP Token url and method
   note over AS: 6.1. (Optional) Checks DPoP token unique identifier
-  note over AS: 7. Checks DPoP signature against Access Token
+  note over AS: 7. Checks DPoP signature against ID Token
   AS->>WebID: 8. Retrieves WebID Document
   WebID->>AS: Profile
   note over AS: 9. Checks Issuer
@@ -21,7 +21,7 @@ sequenceDiagram
   OP->>AS: OP configuration
   AS->>OP: 11. Requests JWKS
   OP->>AS: JWKS
-  note over AS: 12. Checks access token signature validity
+  note over AS: 12. Checks ID token signature validity
   AS->>Client: 13. Access Token Response
   Client->>RS: 14. Sends Request with Access Token
   note over AS, RS: Have pre-established usage of Access Tokens


### PR DESCRIPTION
As discussed with @elf-pavlik, some fixes and improvements in the Primer:
- Steps 7 and 12 of the Request flow diagram was refering to access token instead of ID token.
- Show the kid in the ID Token at step 19 of the Authorization code PKCE flow.
- Add a reference to RFC7515 section 4.1.4 in step 12 of the Request flow.

See https://github.com/solid/solid-oidc/issues/229.