### PR TITLE
Make CliendID URIs a MUST

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -142,7 +142,7 @@ Details of the flow are available in [[!SOLID-OIDC-PRIMER]]
 
 OAuth and OIDC require the Client application to identify itself to the OP and RS by presenting a
 [client identifier](https://tools.ietf.org/html/rfc6749#section-2.2) (Client ID). Solid applications
-SHOULD use a URI that can be dereferenced as a [Client ID Document](#clientids-document).
+MUST use a URI that can be dereferenced as a [Client ID Document](#clientids-document).
 
 Issue(78):
 


### PR DESCRIPTION
This is intended as a conversation starter. If we want to have proper client constraints, for example, `acp:client,` we need reliable global identifiers for clients. DynReg could be useful during early development, but production systems must always use URIs to denote clients. This way, the `redirect_uri` gets verified. 

related: 
* https://github.com/solid/security-considerations/issues/17