### PR TITLE
add Christoph Braun to editors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15,7 +15,8 @@ Markup Shorthands: markdown yes
 Max ToC Depth: 2
 Editor: [Aaron Coburn](https://people.apache.org/~acoburn/#i) ([Inrupt](https://inrupt.com))
 Editor: [elf Pavlik](https://elf-pavlik.hackers4peace.net)
-Editor: [Dmitri Zagidulin](http://computingjoy.com/)
+Editor: Christoph Braun (Forschungszentrum Informatik (FZI))
+Former Editor: [Dmitri Zagidulin](http://computingjoy.com/)
 Former Editor: [Adam Migus](https://migusgroup.com/about/) ([The Migus Group](https://migusgroup.com/))
 Former Editor: [Ricky White](https://endlesstrax.com) ([The Migus Group](https://migusgroup.com/))
 Test Suite: https://solid-contrib.github.io/solid-oidc-tests/

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -17,6 +17,7 @@ Editor: [Jackson Morgan](https://github.com/jaxoncreed)
 Editor: [Aaron Coburn](https://github.com/acoburn)
 Editor: [Matthieu Bosquet](https://github.com/matthieubosquet)
 Editor: [elf Pavlik](https://elf-pavlik.hackers4peace.net)
+Editor: Christoph Braun (Forschungszentrum Informatik (FZI))
 Metadata Order: This version, Latest published version, Test Suite, Created, Modified, *, !*
 Abstract:
   The Solid OpenID Connect (Solid-OIDC) specification defines how resource servers


### PR DESCRIPTION
@uvdsl is one of Solid CG chairs, maintains https://github.com/uvdsl/solid-oidc-client-browser and has implemented and published about various topics based on Solid AuthN/AuthZ including work on MANDAT (which was presented at Solid World, Solid Practicioners, and Solid GG)

@dmitrizagidulin I also updated your status from Editor to Former Editor. It's mostly to reflect your limited engagement in recent years. If you prefer to stay listed as active Editor I'll just revert that change! We can also handle it as separate PR

@jeswr after we merge it could you plese also update permissions on this repo?