### PR TITLE
Update former editor link for Ricky White

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -17,7 +17,7 @@ Editor: [Aaron Coburn](https://people.apache.org/~acoburn/#i) ([Inrupt](https://
 Editor: [elf Pavlik](https://elf-pavlik.hackers4peace.net)
 Editor: [Dmitri Zagidulin](http://computingjoy.com/)
 Former Editor: [Adam Migus](https://migusgroup.com/about/) ([The Migus Group](https://migusgroup.com/))
-Former Editor: [Ricky White](https://endlesstrax.com) ([The Migus Group](https://migusgroup.com/))
+Former Editor: [Ricky White](https://rickywhite.net) ([The Migus Group](https://migusgroup.com/))
 Test Suite: https://solid-contrib.github.io/solid-oidc-tests/
 Metadata Order: This version, Latest published version, Test Suite, Created, Modified, *, !*
 Abstract:


### PR DESCRIPTION
I've reached out to Ricky on email. Maybe he will respond here, but I would argue it is pretty safe to update the link, considering it resolves to something non too serious looking at the moment.