### PR TITLE
Capture Solid-OIDC with Global Access Token

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,5 +5,11 @@
 # pipx install bikeshed
 # bikeshed update (to get the latest autolinking data)
 
-for bsdoc in ./*.bs ./**/*.bs; do bikeshed spec $bsdoc; done
-for diagram in primer/*.mmd; do docker run --rm -v "$PWD:/data" minlag/mermaid-cli -i /data/$diagram; done
+# Enable recursive globbing for **
+shopt -s globstar
+
+# 1. Generate ALL diagrams
+for diagram in ./*.mmd ./**/*.mmd; do [ -f "$diagram" ] && docker run --rm -u $(id -u):$(id -g) -v "$PWD:/data" minlag/mermaid-cli -i "/data/$diagram"; done
+
+# 2. Build ALL specs
+for bsdoc in ./*.bs ./**/*.bs; do [ -f "$bsdoc" ] && bikeshed spec "$bsdoc"; done

--- a/snapshot-gat/README.md
+++ b/snapshot-gat/README.md
@@ -1,0 +1,6 @@
+# Solid-OIDC: Global Access Token (GAT) Snapshot
+
+Addresses https://github.com/solid/solid-oidc/issues/250 and captures the authentication flow that all current server and client implementations support (as of 2026-04-21).
+
+This specification version is a snapshot of Solid-OIDC, where a Client uses a global DPOP-bound access token issued by an OpenID Provider to authenticate at an Resource Server.
+

--- a/snapshot-gat/index.bs
+++ b/snapshot-gat/index.bs
@@ -1,0 +1,692 @@
+<pre class='metadata'>
+Title: Solid-OIDC: Global Access Token (GAT) Snapshot
+Boilerplate: issues-index no
+Shortname: solid-oidc-gat
+Level: 1
+Status: CG-DRAFT
+Group: solidcg
+ED: https://solid.github.io/solid-oidc/
+TR: https://solidproject.org/TR/oidc
+!Created: July 16, 2021
+!Modified: [DATE]
+Repository: https://github.com/solid/solid-oidc
+Inline Github Issues: title
+Markup Shorthands: markdown yes
+Max ToC Depth: 2
+Editor: Aaron Coburn, Inrupt, https://people.apache.org/~acoburn/#i
+Editor: elf Pavlik, , https://elf-pavlik.hackers4peace.net
+Editor: Christoph Braun, Forschungszentrum Informatik (FZI)
+Former Editor: Dmitri Zagidulin, , http://computingjoy.com/
+Former Editor: Adam Migus, The Migus Group, https://migusgroup.com/about/
+Former Editor: Ricky White, The Migus Group, https://rickywhite.net
+Test Suite: https://solid-contrib.github.io/solid-oidc-tests/
+Metadata Order: This version, Latest published version, Test Suite, Created, Modified, *, !*
+Abstract:
+  The Solid OpenID Connect (Solid-OIDC) specification defines how resource servers
+  verify the identity of relying parties and end users based on the authentication
+  performed by an OpenID provider. Solid-OIDC builds on top of OpenID Connect 1.0
+  for use within the Solid ecosystem.
+
+  This version is a snapshot of Solid-OIDC, where a Client uses a global DPOP-bound access token
+  issued by an OpenID Provider to authenticate at an Resource Server.
+</pre>
+
+# Introduction # {#intro}
+
+*This section is non-normative*
+
+The [Solid project](https://solidproject.org/) aims to change the way web applications work today to
+improve privacy and user control of personal data by utilizing current standards, protocols, and
+tools, to facilitate building extensible and modular decentralized applications based on
+[Linked Data](https://www.w3.org/standards/semanticweb/data) principles.
+
+This specification is written for Authorization and Resource Server owners intending to implement
+Solid-OIDC. It is also useful to Solid application developers charged with implementing a Solid-OIDC
+client.
+
+The OAuth 2.0 [[!RFC6749]] and OpenID Connect Core 1.0 [[!OIDC-CORE]] web standards were
+published in October 2012 and November 2014, respectively. Since publication they've seen rapid and
+widespread adoption across the industry, in turn gaining extensive *"real-world"* data and
+experience. The strengths of the protocols are now clear; however, in a changing eco-system where
+privacy and control of digital identities are becoming more pressing concerns, it is also clear
+that additional functionality is required.
+
+The additional functionality documented herein aims to address:
+
+1. Resource servers having no existing trust relationship with identity providers.
+2. Ephemeral Clients as a first-order use-case.
+
+<div class="note" title="Version Snapshot">
+  <p>
+    This version is a snapshot of Solid-OIDC, where a Client uses a global DPOP-bound access token
+    issued by an OpenID Provider to authenticate at an Resource Server.
+  </p>
+</div>
+
+# Terminology # {#terms}
+
+*This section is non-normative*
+
+This specification uses the terms "access token", "authorization server", "resource server" (RS), "token endpoint",
+"grant type", and "client" as defined by The OAuth 2.0 Authorization Framework [[!RFC6749]].
+
+Throughout this specification, we will use the term OpenID Provider (OP) in line with the
+terminology used in the Open ID Connect Core 1.0 specification (OIDC) [[!OIDC-CORE]].
+It should be noted that this is distinct from the entity referred to as an Authorization Server
+by the OAuth 2.0 Authorization Framework (OAuth) [[!RFC6749]].
+
+This specification also uses the following terms:
+
+<dl>
+<dt>*WebID* as defined by [[!WEBID]]
+<dd>
+    A WebID is a URI with an HTTP or HTTPS scheme which denotes an Agent (Person, Organization, Group,
+    Device, etc.).
+
+<dt>*JSON Web Token (JWT)* as defined by [[!RFC7519]]
+<dd>
+    A string representing a set of claims as a JSON object that is encoded in a JWS or JWE, enabling the
+    claims to be digitally signed or MACed and/or encrypted.
+
+<dt>*JSON Web Key (JWK)* as defined by [[!RFC7517]]
+<dd>
+    A JSON object that represents a cryptographic key. The members of the object represent properties of
+    the key, including its value.
+
+<dt>*Demonstration of Proof-of-Possession at the Application Layer (DPoP)* as defined by [[!DPOP]]
+<dd>
+    A mechanism for sender-constraining OAuth tokens via a proof-of-possession mechanism on the
+    application level.
+
+<dt>*DPoP Proof* as defined by [[!DPOP]]
+<dd>
+    A DPoP proof is a JWT that is signed (using JWS) using a private key chosen by the client.
+
+<dt>*Proof Key for Code Exchange (PKCE)* as defined by [[!RFC7636]]
+<dd>
+    An extension to the Authorization Code flow which mitigates the risk of an authorization code
+    interception attack.
+</dl>
+
+# Core Concepts # {#concepts}
+
+*This section is non-normative*
+
+In a decentralized ecosystem, such as Solid, an OP may be an identity-as-a-service vendor or, at
+the other end of the spectrum, a user-controlled OP. In either case, the user may be authenticating
+from a browser or an application.
+
+Therefore, this specification assumes the use of the
+[Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps) with
+PKCE, in accordance with OAuth and OIDC best practices. It is also assumed that there are no
+preexisting trust relationships with the OP. This means that client registration, whether dynamic,
+or static, is entirely optional.
+
+## WebIDs ## {#concepts-webids}
+
+*This section is non-normative*
+
+In line with Linked Data principles, a WebID is a HTTP URI that,
+when dereferenced, resolves to a profile document that is structured data in an
+[RDF 1.1 format](https://www.w3.org/TR/rdf11-concepts/). This profile document allows
+people to link with others to grant access to identity resources as they see fit. WebIDs underpin
+Solid and are used as a primary identifier for Users in this specification.
+
+# Basic Flow # {#basic-flow}
+
+*This section is non-normative*
+
+Details of the flow are available in [[!SOLID-OIDC-PRIMER]]
+
+<figure id="fig-signature">
+    <img src="sequence-gat.mmd.svg">
+    <figcaption>Basic sequence of authenticating the user and the client.</figcaption>
+</figure>
+
+# Client Identifiers # {#clientids}
+
+OAuth and OIDC require the Client application to identify itself to the OP and RS by presenting a
+[client identifier](https://tools.ietf.org/html/rfc6749#section-2.2) (Client ID). Solid applications
+SHOULD use a URI that can be dereferenced as a [Client ID Document](#clientids-document).
+
+## Client ID Document ## {#clientids-document}
+
+When a Client Identifier is dereferenced, the resource MUST be serialized as an `application/ld+json` document
+unless content negotiation requires a different outcome.
+
+The serialized JSON form of a Client ID Document MUST use the normative JSON-LD `@context`
+provided at `https://www.w3.org/ns/solid/oidc-context.jsonld` such that the resulting
+document produces a JSON serialization of an OIDC client registration, per the
+definition of client registration metadata from [[!RFC7591]] section 2.
+
+Also, the OP MUST dereference the Client ID Document and match any Client-supplied parameters
+with the values in the Client ID Document.
+
+Further, the `redirect_uri` provided by the Client MUST be included in the registration `redirect_uris`
+list.
+
+This example uses [JSON-LD ](https://www.w3.org/TR/json-ld/) for the Client ID Document:
+
+<div class='example'>
+    <p>https://app.example/id</p>
+
+    <pre highlight="jsonld">
+        {
+          "@context": ["https://www.w3.org/ns/solid/oidc-context.jsonld"],
+
+          "client_id": "https://app.example/id",
+          "client_name": "Solid Application Name",
+          "redirect_uris": ["https://app.example/callback"],
+          "post_logout_redirect_uris": ["https://app.example/logout"],
+          "client_uri": "https://app.example/",
+          "logo_uri" : "https://app.example/logo.png",
+          "tos_uri" : "https://app.example/tos.html",
+          "scope" : "openid profile offline_access webid",
+          "grant_types" : ["refresh_token","authorization_code"],
+          "response_types" : ["code"],
+          "default_max_age" : 3600,
+          "require_auth_time" : true
+        }
+    </pre>
+</div>
+
+Issue(95):
+
+### JSON-LD context ### {#jsonld-context}
+
+This specification defines a JSON-LD context for use with OIDC Client ID Documents. This context is
+available at `https://www.w3.org/ns/solid/oidc-context.jsonld`. Client ID Documents that reference
+this JSON-LD context MUST use the HTTPS scheme.
+
+NOTE: the [Solid-OIDC Vocabulary](https://www.w3.org/ns/solid/oidc) that is part of this context uses the HTTP scheme.
+
+Full content of JSON-LD context can be also seen in [[#full-jsonld-context]]
+
+## OIDC Registration ## {#clientids-oidc}
+
+For non-dereferencable identifiers, the Client MUST present a `client_id` value that has been
+registered with the OP via either OIDC dynamic or static registration.
+See also [[!OIDC-DYNAMIC-CLIENT-REGISTRATION]].
+
+When requesting Dynamic Client Registration, the Client MUST specify the `scope` in the metadata
+and include `webid` in its value (space-separated list).
+
+<div class='example'>
+    <pre highlight="jsonld" line-highlight="9">
+        {
+          "client_name": "S-C-A Browser Demo Client App",
+          "application_type": "web",
+          "redirect_uris": [
+            "https://dynamic-client.example/auth"
+          ],
+          "subject_type": "pairwise",
+          "token_endpoint_auth_method": "client_secret_basic",
+          "scope" : "openid profile offline_access webid"
+        }
+    </pre>
+</div>
+
+# WebID Profile # {#webid-profile}
+
+Dereferencing the WebID URL results in a WebID Profile.
+
+Issue(76):
+
+## OIDC Issuer Discovery ## {#oidc-issuer-discovery}
+
+A WebID Profile lists the OpenID Providers who are trusted to issue tokens on behalf
+of the agent who controls the WebID. This prevents a malicious OpenID Provider from issuing
+otherwise valid ID Tokens for arbitrary WebIDs. An entity that verifies ID Tokens will use this
+mechanism to determine if the issuer is authoritative for the given WebID.
+
+<figure class="example">
+    <pre highlight="turtle">
+      PREFIX solid: &lt;http://www.w3.org/ns/solid/terms#&gt;
+
+      &lt;#id&gt; solid:oidcIssuer &lt;https://oidc.example&gt; .
+    </pre>
+    <figcaption>WebID Profile specifying an OIDC issuer</figcaption>
+</figure>
+
+To discover a list of valid issuers, the WebID Profile MUST be checked for the existence of statements matching
+<pre highlight="sparql">
+  ?webid &lt;http://www.w3.org/ns/solid/terms#oidcIssuer&gt; ?iss .
+</pre>
+where `?webid` is set to WebID. The `?iss` will result in an IRI denoting valid issuer for that WebID.
+The WebID Profile Document MUST include one or more statements matching the OIDC issuer pattern.
+
+Issue(80):
+
+Issue(92):
+
+Issue(91):
+
+### OIDC Issuer Discovery via Link Headers ### {#oidc-issuer-discovery-link-headers}
+
+A server hosting a WebID Profile Document MAY transmit the `http://www.w3.org/ns/solid/terms#oidcIssuer`
+values via Link Headers, but they MUST be the same as in the RDF representation.
+A client MUST treat the RDF in the body of the WebID Profile as canonical
+but MAY use the Link Header values as an optimization.
+
+<figure class="example">
+    <pre highlight="http">
+        Link: &lt;https://oidc.example&gt;;
+              rel="http://www.w3.org/ns/solid/terms#oidcIssuer";
+              anchor="#id"
+    </pre>
+    <figcaption>HTTP response Link Header (line breaks added for readibility)</figcaption>
+</figure>
+
+
+# Requesting the WebID Claim using a Scope Value # {#webid-scope}
+
+Solid-OIDC uses scope values, as defined in [[!RFC6749]] Section 3.3 and [[!OIDC-CORE]] Section 5.4 to specify
+what information is made available as Claim Values.
+
+Solid-OIDC defines the following `scope` value for use with claim requests:
+
+<dl>
+<dt>*webid*
+<dd>
+    REQUIRED. This scope requests access to the End-User's `webid` Claim.
+</dl>
+
+
+# Issuer Validation after receiving the Authorization Code # {#iss-check}
+
+In accordance with Best Current Practice [[RFC9700]], 
+defense against [Mix-Up Attacks](https://www.rfc-editor.org/rfc/rfc9700.html#section-4.4) 
+is required in Solid-OIDC as clients are expected to interact with more than one OP. 
+To this end, this specification adopts the mechanism defined in [[!RFC9207]].
+
+The OP MUST include the `iss` query parameter alongside the authorization code when redirecting the user agent back to the Client's redirect_uri.
+The value of the `iss` parameter MUST be the Issuer Identifier of the OP, as defined in [[OIDC-CORE]].
+<figure class="example">
+    <pre highlight="http">
+HTTP/1.1 302 Found
+Location: https://client.example.com/callback?
+                                        code=n0esc392ae491076
+                                        &amp;state=af0ifjsldkj
+                                        &amp;iss=https%3A%2F%2Fidp.example.com
+    </pre>
+    <figcaption>Example Authorization Response including the `iss` query parameter</figcaption>
+</figure>
+
+Upon receiving the authorization response, the Client MUST validate the `iss` parameter:
+* The Client MUST check for the presence of the `iss` parameter.
+* The Client MUST verify that the `iss` value matches the Issuer Identifier of the OP to which the authorization request was sent.
+
+If the `iss` parameter is missing or does not match the expected value, the Client MUST reject the response, MUST NOT exchange the authorization code for tokens, and SHOULD signal an error to the user.
+
+
+# Token Instantiation # {#tokens}
+
+Assuming one of the following options
+ - Client ID and Secret, and valid DPoP Proof (for dynamic and static registration)
+ - Dereferencable Client Identifier with a proper Client ID Document and valid DPoP Proof (for a Solid client identifier)
+
+the OP MUST return two tokens to the Client:
+
+1. A DPoP-bound Access Token
+2. An OIDC ID Token
+
+<div class="note" title="Difference to Solid-OIDC 0.1.0">
+    <p>
+        This version of Solid-OIDC relies on a global DPOP-bound access token issued by the OpenID Provider (OP) to authenticate a Client at a Resource Server (RS).
+    </p>
+    <p>
+        Solid-OIDC 0.1.0 relies the concept of <em>Authorization Servers (AS)</em> that manage access to the Resource Servers under their authority ("realm").
+        To access data provided by an RS, a Client needs to obtain an access token issued by the AS that the RS is overseen by.
+        To obtain such an access token, the Client needs to successfully authenticating at and be indeed authorized by the AS to access the desired data. 
+        To authenticate at the AS, the Client presents the OIDC ID token obtained from their OP.
+    </p>
+    <p>
+        Solid-OIDC 0.1.0 thus mandates:
+        <ul>
+            <li>An OP is no longer required to issue an access token.</li>
+            <li>An OP is required to issue a DPOP-bound OIDC ID Token to a Client.</li>
+            <li>This DPOP-bound OIDC ID Token is to be exchanged for an access token at the AS managing access to an RS.</li>
+            <li>The AS of an RS is to be discovered via Link headers in an RS' HTTP response.</li>
+        </ul>
+</div>
+
+## DPoP-bound Access Token ## {#tokens-access}
+
+The DPoP-bound Access Token MUST be a valid JWT. See also: [[!RFC7519]].
+
+When requesting a DPoP-bound Access Token, the Client MUST send a DPoP proof JWT
+that is valid according to the [[DPOP#section-5]]. The DPoP proof JWT is used to
+bind the access token to a public key. See also: [[!DPOP]].
+
+With the `webid` scope, the DPoP-bound Access Token payload MUST contain these claims:
+ * `webid` — The WebID claim MUST be the user's WebID.
+ * `iss` — The issuer claim MUST be a valid URL of the OP
+    instantiating this token.
+ * `aud` — The audience claim MUST either be the string `solid` or be an array
+    of values, one of which is the string `solid`. In the decentralized world
+    of Solid OIDC, the principal of an access token is not a specific endpoint,
+    but rather any Solid API; that is, any Solid server at any accessible address
+    on the world wide web. See also: [[RFC7519#section-4.1.3]].
+ * `iat` — The issued-at claim is the time at which the DPoP-bound
+    Access Token was issued.
+ * `exp` — The expiration claim is the time at which the DPoP-bound
+    Access Token becomes invalid.
+ * `cnf` — The confirmation claim is used to identify the DPoP Public
+    Key bound to the Access Token. See also: [[DPOP#section-7]].
+ * `client_id` - The ClientID claim is used to identify the client. See also:
+    [section 5. Client Identifiers](#clientids).
+
+<div class="example">
+    <p>An example DPoP-bound Access Token:
+
+    <pre highlight="json">
+    {
+        "webid": "https://janedoe.com/web#id",
+        "sub": "https://janedoe.com/web#id"
+        "client_id": "https://client.example.com/web#id"
+        "iss": "https://idp.example.com",
+        "aud": "solid",
+        "iat": 1541493724,
+        "exp": 1573029723,
+        "cnf":{
+          "jkt":"0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+        },
+    }
+    </pre>
+</div>
+
+## OIDC ID Token ## {#tokens-id}
+
+When requesting the `webid` scope, the user's WebID MUST be present in the ID Token as the `webid` claim.
+
+<div class="example">
+    <p>An example OIDC ID Token:
+
+    <pre highlight="json">
+        {
+            "webid": "https://janedoe.com/web#id",
+            "sub": "https://janedoe.com/web#id",
+            "azp": "https://client.example.com/web#id",
+            "iss": "https://idp.example.com",
+            "aud": ["https://client.example.com/web#id","solid"],
+            "nonce": "n-0S6_WzA2Mj",
+            "exp": 1311281970,
+            "iat": 1311280970,
+        }
+    </pre>
+</div>
+
+Issue(47):
+
+## Token Validation ## {#token-validation}
+
+A verifying party MUST reject non-conforming tokens.
+
+In addition, an access token MUST be validated according to [OIDC-CORE, Section 3.1.3.8](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowTokenValidation).
+In addition, an ID Token MUST be validated according to [OIDC-CORE, Section 3.1.3.7](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation)
+
+The verifying party MUST perform [[#oidc-issuer-discovery]] using the value of the `webid` claim
+to dereference the WebID Profile Document.
+
+Unless the verifying party acquires OP keys through some other means, or it chooses to reject tokens issued by this OP,
+the verifying party MUST follow OpenID Connect Discovery 1.0 [[!OIDC-DISCOVERY]] to find an OP's signing keys (JWK).
+
+# Resource Access # {#resource}
+
+When a Client performs an unauthenticated request to a protected resource,
+the Resource Server MUST respond with the HTTP <code>401</code> status code,
+and a <code>WWW-Authenticate</code> HTTP header. See also: [[RFC9110]](11.6.1. WWW-Authenticate)
+
+When a Client performs an authenticated request, i.e., using the DPOP-bound access token issued by the OP and a self-issued DPOP token, the Resource Server MUST perform [[#dpop-validation]] and [[#token-validation]].
+
+
+## DPoP Validation ## {#dpop-validation}
+
+A DPoP Proof that is valid according to
+[RFC9449](https://datatracker.ietf.org/doc/html/rfc9449#section-4.3),
+MUST be present when a DPoP-bound Access Token is used.
+
+The DPoP-bound Access Token MUST be validated according to
+[RFC9449](https://datatracker.ietf.org/doc/html/rfc9449#section-6),
+but the RS MAY perform additional verification in order to determine whether to grant access to the
+requested resource.
+
+# Solid-OIDC Conformance Discovery # {#discovery}
+
+An OpenID Provider that conforms to the Solid-OIDC specification MUST advertise it in the OpenID Connect
+Discovery 1.0 [[!OIDC-DISCOVERY]] resource by including `webid` in its `scopes_supported` metadata property.
+
+<div class="example">
+    <pre highlight="json">
+        {
+            "scopes_supported": ["openid", "offline_access", "webid"]
+        }
+    </pre>
+</div>
+
+# Security Considerations # {#security}
+
+*This section is non-normative*
+
+As this specification builds upon existing web standards, security considerations from OAuth, OIDC,
+PKCE, and the DPoP specifications may also apply unless otherwise indicated. The following
+considerations should be reviewed by implementors and system/s architects of this specification.
+
+Some of the references within this specification point to documents with a
+Living Standard or Draft status, meaning their contents can still change over
+time. It is advised to monitor these documents, as such changes might have
+security implications.
+
+In addition to above considerations, implementors should consider the Security
+Considerations in context of the Solid Protocol [[!SOLID-PROTOCOL]].
+
+## TLS Requirements ## {#security-tls}
+
+All TLS requirements outlined in [[BCP195]] apply to this
+specification.
+
+All tokens, Client, and User credentials MUST only be transmitted over TLS.
+
+## Client IDs ## {#security-client-ids}
+
+An RS SHOULD assign a fixed set of low trust policies to any client identified as anonymous.
+
+Implementors SHOULD expire ephemeral Client IDs that are kept in server storage to mitigate the
+potential for a bad actor to fill server storage with unexpired or otherwise useless Client IDs.
+
+## Client Secrets ## {#security-client-secrets}
+
+Client secrets SHOULD NOT be stored in browser local storage. Doing so will increase the risk of
+data leaks should an attacker gain access to Client credentials.
+
+## Client Trust ## {#security-client-trust}
+
+*This section is non-normative*
+
+Clients are ephemeral, client registration is optional, and most Clients cannot keep secrets. These,
+among other factors, are what makes Client trust challenging.
+
+# Privacy Considerations # {#privacy}
+
+## Access Token Reuse ## {#privacy-token-reuse}
+
+*This section is non-normative*
+
+With JWTs being extendable by design, there is potential for a privacy breach if Access Tokens get
+reused across multiple resource servers. It is not unimaginable that a custom claim is added to the
+Access Token on instantiation. This addition may unintentionally give other resource servers
+consuming the Access Token information about the user that they may not wish to share outside of the
+intended RS.
+
+# Acknowledgments # {#acknowledgments}
+
+*This section is non-normative*
+
+The Solid Community Group would like to thank the following individuals for reviewing and providing
+feedback on the specification (in alphabetical order):
+
+Tim Berners-Lee, Justin Bingham, Sarven Capadisli, Aaron Coburn, Matthias Evering, Jamie Fiedler,
+Michiel de Jong, Ted Thibodeau Jr, Kjetil Kjernsmo, Mitzi László, Pat McBennett, Adam Migus, Jackson Morgan, Davi
+Ottenheimer, Justin Richer, severin-dsr, Henry Story, Michael Thornburgh, Emmet Townsend, Ruben
+Verborgh, Ricky White, Paul Worrall, Dmitri Zagidulin.
+
+# Appendix A: Full JSON-LD context # {#full-jsonld-context}
+
+The JSON-LD context is defined as:
+
+<pre highlight="jsonld">
+  {
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "oidc": "http://www.w3.org/ns/solid/oidc#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "client_id": {
+        "@id": "@id",
+        "@type": "@id"
+      },
+      "client_uri": {
+        "@id": "oidc:client_uri",
+        "@type": "@id"
+      },
+      "logo_uri": {
+        "@id": "oidc:logo_uri",
+        "@type": "@id"
+      },
+      "policy_uri": {
+        "@id": "oidc:policy_uri",
+        "@type": "@id"
+      },
+      "tos_uri": {
+        "@id": "oidc:tos_uri",
+        "@type": "@id"
+      },
+      "redirect_uris": {
+        "@id": "oidc:redirect_uris",
+        "@type": "@id",
+        "@container": [
+          "@id",
+          "@set"
+        ]
+      },
+      "require_auth_time": {
+        "@id": "oidc:require_auth_time",
+        "@type": "xsd:boolean"
+      },
+      "default_max_age": {
+        "@id": "oidc:default_max_age",
+        "@type": "xsd:integer"
+      },
+      "application_type": {
+        "@id": "oidc:application_type"
+      },
+      "client_name": {
+        "@id": "oidc:client_name"
+      },
+      "contacts": {
+        "@id": "oidc:contacts"
+      },
+      "grant_types": {
+        "@id": "oidc:grant_types"
+      },
+      "response_types": {
+        "@id": "oidc:response_types"
+      },
+      "scope": {
+        "@id": "oidc:scope"
+      },
+      "token_endpoint_auth_method": {
+        "@id": "oidc:token_endpoint_auth_method"
+      }
+    }
+  }
+</pre>
+
+<pre class=biblio>
+{
+    "DPOP": {
+        "authors": [
+            "D. Fett",
+            "B. Campbell",
+            "J. Bradley",
+            "T. Lodderstedt",
+            "M. Jones",
+            "D. Waite"
+        ],
+        "href": "https://datatracker.ietf.org/doc/html/rfc9449",
+        "title": "OAuth 2.0 Demonstration of Proof-of-Possession at the Application Layer (DPoP)",
+        "publisher": "IETF"
+    },
+    "OIDC-CORE": {
+        "authors": [
+            "N. Sakimura",
+            "J. Bradley",
+            "M. Jones",
+            "B. de Medeiros",
+            "C. Mortimore"
+        ],
+        "href": "https://openid.net/specs/openid-connect-core-1_0.html",
+        "title": "OpenID Connect Core 1.0",
+        "publisher": "The OpenID Foundation"
+    },
+    "OIDC-DISCOVERY": {
+        "authors": [
+            "N. Sakimura",
+            "J. Bradley",
+            "M. Jones",
+            "E. Jay"
+        ],
+        "href": "https://openid.net/specs/openid-connect-discovery-1_0.html",
+        "title": "OpenID Connect Discovery 1.0",
+        "publisher": "The OpenID Foundation"
+    },
+    "OIDC-DYNAMIC-CLIENT-REGISTRATION": {
+        "authors": [
+            "N. Sakimura",
+            "J. Bradley",
+            "M.B. Jones"
+        ],
+        "href": "https://openid.net/specs/openid-connect-registration-1_0.html",
+        "title": "OpenID Connect Dynamic Client Registration 1.0",
+        "publisher": "The OpenID Foundation"
+    },
+    "SOLID-PROTOCOL": {
+        "authors": [
+            "Sarven Capadisli",
+            "Tim Berners-Lee",
+            "Ruben Verborgh",
+            "Kjetil Kjernsmo",
+            "Justin Bingham",
+            "Dmitri Zagidulin"
+        ],
+        "href": "https://solidproject.org/TR/protocol",
+        "title": "Solid Protocol",
+        "publisher": "W3C Solid Community Group"
+    },
+    "SOLID-OIDC-PRIMER": {
+        "authors": [
+            "Jackson Morgan",
+            "Aaron Coburn",
+            "Matthieu Bosquet"
+        ],
+        "href": "https://solid.github.io/solid-oidc/primer/",
+        "title": "Solid-OIDC Primer",
+        "publisher": "W3C Solid Community Group"
+    },
+    "WEBID": {
+        "authors": [
+            "Andrei Sambra",
+            "Henry Story",
+            "Tim Berners-Lee"
+        ],
+        "href": "https://www.w3.org/2005/Incubator/webid/spec/identity/",
+        "title": "WebID 1.0",
+        "publisher": "WebID Incubator Group"
+    },
+    "BCP195": {
+        "href": "https://www.rfc-editor.org/info/bcp195",
+        "title": "Best Current Practice 195",
+        "publisher": "IETF"
+    }
+}
+</pre>

--- a/snapshot-gat/sequence-gat.mmd
+++ b/snapshot-gat/sequence-gat.mmd
@@ -1,0 +1,30 @@
+sequenceDiagram
+  participant WebID as 👩 End-User's WebID Document
+  participant OP as 👩 OpenID Provider
+  participant ClientID as ⚙️ Client's ID Document
+  participant C as ⚙️ Client
+  participant RS as ☁️ Resource Server
+
+  C ->> RS: unauthenticated request
+  RS ->> C: 401 with a WWW-Authenticate HTTP header
+  Note over C: 👩 User provides their WebID ⌨️
+  C ->> WebID: get WebID document to discover OpenID Provider
+  WebID ->> C: WebID document
+  C ->> OP: start Authorization Code grant
+  OP->> ClientID: get Client ID document
+  ClientID->> OP: ClientID document
+  Note over OP: compare redirect_uri
+  OP ->> C: return Authorization Code
+  C ->> OP: present Authorization Code and DPoP proof
+  Note over OP:  ⚙️ Client is authenticated ✅
+  OP ->> C: return DPoP bound Access Token and OIDC ID Token
+  Note over C: ⚙️ Client validates OP 
+  Note over C: 👩 User is authenticated ✅
+  C ->> RS: request with DPOP-bound Access Token and DPoP Token
+  RS ->> WebID: get WebID document to verify OpenID Provider
+  WebID ->> RS: WebID document
+  RS ->> OP: get OP's public key to verify ID Token (JWS)
+  OP ->> RS: JWKS
+Note over RS: ☁️ RS verify DPoP-bound Access Token and DPoP Token
+  Note over RS: 👩 User and ⚙️ Client are authenticated ✅
+  RS ->> C: resource representation


### PR DESCRIPTION
Addresses https://github.com/solid/solid-oidc/issues/250 and captures the authentication flow that all current server and client implementations support (as of 2026-04-21).

This specification version is a snapshot of Solid-OIDC, where a Client uses a global DPOP-bound access token issued by an OpenID Provider to authenticate at an Resource Server.

