### PR TITLE
Relax client credentials grant requirement to SHOULD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -443,7 +443,7 @@ Discovery 1.0 [[!OIDC-DISCOVERY]] resource by including `webid` in its `scopes_s
 NOTE: This sections borrows concepts from OAuth 2.0 [[!RFC6749]], while the rest of Solid-OIDC builds on top of OpenID
 Connect Core 1.0 [[!OIDC-CORE]]. The section is likely to be extracted into a separate specification in the future.
 
-Authorization Servers MUST support the OAuth 2.0 Client Credentials Grant [[!RFC6749]] (Section 4.4) to enable
+Authorization Servers SHOULD support the OAuth 2.0 Client Credentials Grant [[!RFC6749]] (Section 4.4) to enable
 non-interactive authentication for scripts, automated agents, and server-to-server communication.
 
 NOTE: Scripts and bots can also use Solid-OIDC without Client Credentials via the [refresh token

--- a/index.bs
+++ b/index.bs
@@ -470,10 +470,10 @@ credentials.
 
 ## Solid-OIDC Conformance Discovery ## {#client-credentials-discovery}
 
-For non-interactive use cases such as scripts, automated agents, and server-to-server communication, this specification
-also requires that an OpenID Provider that conforms to the Solid-OIDC specification MUST advertise its support for the
-[Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4) in the OpenID Connect Discovery 1.0
-[OIDC.Discovery] resource by including `client_credentials` in its `grant_types_supported` metadata property.
+For non-interactive use cases such as scripts, automated agents, and server-to-server communication, an OpenID Provider
+that supports the [Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4) MUST advertise that
+support in the OpenID Connect Discovery 1.0 [OIDC.Discovery] resource by including `client_credentials` in its
+`grant_types_supported` metadata property.
 
 <div class="example">
     <pre highlight="json">


### PR DESCRIPTION
## Summary

Updates the Solid-OIDC text to change support for OAuth 2.0 Client Credentials Grant from **MUST** to **SHOULD** in the Authorization Servers section.

## Why

The original goal of adding Client Credentials language was to reflect a way script-based authentication can be done on Solid servers today.

Because not all Solid servers currently implement Client Credentials, this requirement has been downgraded from **MUST** to **SHOULD** to keep that path strongly recommended without making it universally mandatory.

## Changes

- In `index.bs`, changed:
  - `Authorization Servers MUST support ...`
  - to `Authorization Servers SHOULD support ...`
