### PR TITLE
Editorial: fix formatting of editors and their companies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13,12 +13,12 @@ Repository: https://github.com/solid/solid-oidc
 Inline Github Issues: title
 Markup Shorthands: markdown yes
 Max ToC Depth: 2
-Editor: [Aaron Coburn](https://people.apache.org/~acoburn/#i) ([Inrupt](https://inrupt.com))
-Editor: [elf Pavlik](https://elf-pavlik.hackers4peace.net)
-Editor: Christoph Braun (Forschungszentrum Informatik (FZI))
-Former Editor: [Dmitri Zagidulin](http://computingjoy.com/)
-Former Editor: [Adam Migus](https://migusgroup.com/about/) ([The Migus Group](https://migusgroup.com/))
-Former Editor: [Ricky White](https://rickywhite.net) ([The Migus Group](https://migusgroup.com/))
+Editor: Aaron Coburn, Inrupt https://inrupt.com, https://github.com/acoburn
+Editor: elf Pavlik, https://elf-pavlik.hackers4peace.net
+Editor: Christoph Braun, Forschungszentrum Informatik (FZI) https://www.fzi.de, https://github.com/uvdsl
+Former Editor: Dmitri Zagidulin, http://computingjoy.com/
+Former Editor: Adam Migus, The Migus Group https://migusgroup.com, https://migusgroup.com/about/
+Former Editor: Ricky White, The Migus Group https://migusgroup.com/, https://rickywhite.net
 Test Suite: https://solid-contrib.github.io/solid-oidc-tests/
 Metadata Order: This version, Latest published version, Test Suite, Created, Modified, *, !*
 Abstract:

--- a/index.bs
+++ b/index.bs
@@ -3,8 +3,9 @@ Title: Solid-OIDC
 Boilerplate: issues-index no
 Shortname: solid-oidc
 Level: 1
-Status: CG-DRAFT
+Org: W3C
 Group: solidcg
+Status: CG-DRAFT
 ED: https://solid.github.io/solid-oidc/
 TR: https://solidproject.org/TR/oidc
 !Created: July 16, 2021

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -4,8 +4,9 @@ Boilerplate: issues-index no
 Boilerplate: omit conformance
 Shortname: solid-oidc-primer
 Level: 1
-Status: CG-DRAFT
+Org: W3C
 Group: solidcg
+Status: CG-DRAFT
 ED: https://solid.github.io/solid-oidc/primer/
 TR: https://solidproject.org/TR/oidc-primer
 !Created: March 28, 2022

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -13,11 +13,11 @@ TR: https://solidproject.org/TR/oidc-primer
 Repository: https://github.com/solid/solid-oidc
 Markup Shorthands: markdown yes
 Max ToC Depth: 2
-Editor: [Jackson Morgan](https://github.com/jaxoncreed)
-Editor: [Aaron Coburn](https://github.com/acoburn)
-Editor: [Matthieu Bosquet](https://github.com/matthieubosquet)
-Editor: [elf Pavlik](https://elf-pavlik.hackers4peace.net)
-Editor: Christoph Braun (Forschungszentrum Informatik (FZI))
+Editor: Jackson Morgan, https://github.com/jaxoncreed
+Editor: Aaron Coburn, https://github.com/acoburn
+Editor: Matthieu Bosquet, https://github.com/matthieubosquet
+Editor: elf Pavlik, https://elf-pavlik.hackers4peace.net
+Editor: Christoph Braun, Forschungszentrum Informatik (FZI) https://www.fzi.de, https://github.com/uvdsl
 Metadata Order: This version, Latest published version, Test Suite, Created, Modified, *, !*
 Abstract:
   The Solid OpenID Connect (Solid-OIDC) specification defines how resource servers

--- a/primer/index.bs
+++ b/primer/index.bs
@@ -15,7 +15,7 @@ Repository: https://github.com/solid/solid-oidc
 Markup Shorthands: markdown yes
 Max ToC Depth: 2
 Editor: Jackson Morgan, https://github.com/jaxoncreed
-Editor: Aaron Coburn, https://github.com/acoburn
+Editor: Aaron Coburn, Inrupt https://inrupt.com, https://github.com/acoburn
 Editor: Matthieu Bosquet, https://github.com/matthieubosquet
 Editor: elf Pavlik, https://elf-pavlik.hackers4peace.net
 Editor: Christoph Braun, Forschungszentrum Informatik (FZI) https://www.fzi.de, https://github.com/uvdsl

--- a/setup.sh
+++ b/setup.sh
@@ -5,5 +5,11 @@
 # pipx install bikeshed
 # bikeshed update (to get the latest autolinking data)
 
-for bsdoc in ./*.bs ./**/*.bs; do bikeshed spec $bsdoc; done
-for diagram in primer/*.mmd; do docker run --rm -v "$PWD:/data" minlag/mermaid-cli -i /data/$diagram; done
+# Enable recursive globbing for **
+shopt -s globstar
+
+# 1. Generate ALL diagrams
+for diagram in ./*.mmd ./**/*.mmd; do [ -f "$diagram" ] && docker run --rm -u $(id -u):$(id -g) -v "$PWD:/data" minlag/mermaid-cli -i "/data/$diagram"; done
+
+# 2. Build ALL specs
+for bsdoc in ./*.bs ./**/*.bs; do [ -f "$bsdoc" ] && bikeshed spec "$bsdoc"; done


### PR DESCRIPTION
This PR is just fixing some rendering errors and adding the W3C org to the bikeshed file.
I also updated the `setup.sh` file to properly build all the diagrams and all the specs regardless on which folder level they are (and not only one level down).